### PR TITLE
Fix packaging

### DIFF
--- a/elfeed-autotag.el
+++ b/elfeed-autotag.el
@@ -8,7 +8,7 @@
 ;; Version: 0.1
 ;; Keywords: news
 ;; Homepage: https://github.com/paulelms/elfeed-autotag
-;; Package-Requires: ((emacs "27.1") (elfeed "3.4.1") (org "8.2.7") (dash "2.10.0") (s "1.9.0"))
+;; Package-Requires: ((emacs "27.1") (elfeed "3.4.1") (elfeed-protocol "0.8.0") (org "8.2.7") (dash "2.10.0") (s "1.9.0"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -32,7 +32,9 @@
 ;;; Code:
 
 (require 'elfeed)
+(require 'elfeed-protocol)
 (require 'org)
+(require 'org-element)
 (require 'dash)
 (require 's)
 (require 'cl-lib)


### PR DESCRIPTION
- add missing dependency(elfeed-protocol)
- fix byte-compile warnings

```
elfeed-autotag.el:273:1:Warning: the following functions are not known to be defined:
    org-element-map, org-element-parse-buffer, org-element-property,
    elfeed-protocol-format-subfeed-id
```