### PR TITLE
Refactor to support more keywords and match more efficiently

### DIFF
--- a/elfeed-autotag.el
+++ b/elfeed-autotag.el
@@ -271,14 +271,16 @@ all.  Which in my opinion makes the process more traceable."
   (elfeed-log 'info "elfeed-autotag loaded %i rules"
               (length elfeed-autotag--new-entry-hook)))
 
+(defun elfeed-autotag-load-before-configure ()
+  "Load all feed rules before Elfeed is started."
+  (elfeed-autotag-process elfeed-autotag-files elfeed-autotag-tree-id))
+
 ;;;###autoload
 (defun elfeed-autotag ()
   "Setup auto-tagging rules."
   (interactive)
   (elfeed-log 'info "elfeed-autotag initialized")
-  (defadvice elfeed (before configure-elfeed activate)
-    "Load all feed settings before elfeed is started."
-    (elfeed-autotag-process elfeed-autotag-files elfeed-autotag-tree-id))
+  (advice-add 'elfeed :before #'elfeed-autotag-load-before-configure)
   (add-hook 'elfeed-new-entry-hook #'elfeed-autotag--run-new-entry-hook))
 
 (provide 'elfeed-autotag)


### PR DESCRIPTION
## Refactor
Replace the static handling of to only handle feed-url and entry-title
but a list of possible keywords. Each function which is handling
multiple keywords at a time or had to match against one specific word
now uses the keyword list.

Also instead of trying to further process the handling of a keyword
after no possible matches have been found stop processing the keyword
handling of that word.

The functions who tried to find a possible match do now not first
create a list with successful and unsuccessful matches and then filter
the unsuccessful ones out but use the matcher function directly with
the filter function to decide which headlines should be returned.

The function which converts a headline to tagger params used to return
a list with an empty string when the tagger keyword did not have a
parameter following the rest of the headline. Return an empty string
as the parameter to the tagger matcher resulted in false elfeed tagger
hooks being created, these hooks then tagged any entry with the tags
belonging to the headline and it's parent headlines.
Now it returns nil on the headlines which do not have a parameter
after a matcher keyword.

Replace calls to dash with builtin sequence manipulation functions and
s with builtin subroutines for string handling. The result is besides
fewer dependencies more efficient execution.

Also fix the documentation string of some the functions.

## Advice
Port from deprecated `defadvice` to `advice-add`.